### PR TITLE
Fixing Protocol Defs

### DIFF
--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -3,7 +3,7 @@ defmodule <%= name %> do
   use Protobuf<%= options %>
 
   <%= typespec %>
-  @derive [DeepMerge.Resolver]
+  @derive [Jason.Encoder]
   defstruct [<%= struct_fields %>]
 
   <%= if not is_nil(desc) do %>
@@ -24,12 +24,6 @@ defmodule <%= name %> do
   <%= if not is_nil(extensions) do %>
   extensions <%= extensions %>
   <% end %>
-end
-
-defmodule <%= name %>.ProtocolDef do
-  @moduledoc false
-  require Protocol
-  Protocol.derive(Jason.Encoder, <%= name %>)
 end
 
 defimpl DeepMerge.Resolver, for: <%= name %> do


### PR DESCRIPTION
Since we're the default `ANY` struct implementation for Jason, we just use `@derived`. Since we have an explicit impl for Deepmerge, we don't add it to `@derived`.

This solves the wall of warnings from normal compilation (+ marginally speeding up compilation time)

Also, since the time we forked protobuf-elixir, they've gotten a proto3-compatible google-spec JSON encoder + decoder following the official spec here: https://developers.google.com/protocol-buffers/docs/proto3#json. We can consider pulling in those changes vs using our current default `Jason` implementation if we want the wire format to be consistent.